### PR TITLE
Code formatting

### DIFF
--- a/toolkit/index.md
+++ b/toolkit/index.md
@@ -25,11 +25,17 @@ Suggested:
 * Fork your repositories off of the main repositories of FlightNode.
 * Install Git & Git.commandline using Chocolatey. Prefer not to use Git through Visual Studio Community Edition. Visual Studio Code still has some reasonable GUI control for GitHub.
 * Locally, create a directory called 'Workspaces' (or any name of your choice).
-* In Windows explorer, right-click on 'Workspaces' and choose Git Bash. That will open the Unix-like bash prompt window, with c:\Workspaces as the current working directory.
-* mkdir FlightNode
-* cd FlightNode git clone https://github.com/<username>/FlightNode.Identity
-* cd FlightNode git clone https://github.com/<username>/FlightNode.Common
-* cd FlightNode git clone https://github.com/<username>/flightnode.github.io
+* In Windows explorer, right-click on 'Workspaces' and choose Git Bash. That will open the Unix-like bash prompt window, 
+  with c:\Workspaces as the current working directory. Run these commands
+  to create your local repositories (note - there will be more than these three in the future): 
+
+````bash
+> mkdir FlightNode
+> cd FlightNode git clone https://github.com/<username>/FlightNode.Identity
+> cd FlightNode git clone https://github.com/<username>/FlightNode.Common
+> cd FlightNode git clone https://github.com/<username>/flightnode.github.io
+````
+
 * If you are new to GitHub, then here is a fun tutorial to get you started https://try.github.io/levels/1/challenges/1
 
 ## Testing


### PR DESCRIPTION
@kpunjani I wanted to format the command line nicely. In markdown you normally do so by putting four spaces before the line of text, or use the ` backtick `like this`. However, with GitHub Pages, there is also a format that uses four backticks. I'm going to see if this works.
